### PR TITLE
feat: send app version and client type with results to Firebase

### DIFF
--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -15,6 +15,7 @@ import { decode } from 'base-64'
 import { mapStores } from 'pinia'
 import { i18nRoute } from '@/i18n/translation'
 import { useCurrentUserStore } from '@/stores/currentUser'
+import { version } from '../../package.json'
 import matchIcon from '@/utils/matchIcon'
 import BasicPage from '@/components/BasicPage.vue'
 import CompareProject from '@/components/CompareProject.vue'
@@ -55,9 +56,14 @@ export default defineComponent({
       saveResults: (results, startTime) => {
         const numberOfTasks = Object.keys(results).length
         const endTime = new Date().toISOString()
+        const dev = import.meta.env.DEV
+        const appVersion = version + (dev ? '-dev' : '')
+        const clientType = 'web'
         this.mappingSpeed = (Date.parse(endTime) - Date.parse(startTime)) / numberOfTasks
 
         const entry = {
+          appVersion,
+          clientType,
           endTime,
           results,
           startTime,


### PR DESCRIPTION
With this PR, the web app sends `appVersion` with mapping results to Firebase, just as the mobile app does. This is to ensure that results for Validate projects with custom options are accepted.

To distinguish between mobile and app version, we additionally write `clientType` with value "web" to the results entry. This will also facilitate further analysis of web and mobile app usage.

Refers https://github.com/mapswipe/mapswipe/issues/852
Fixes #18