### PR TITLE
Fix/handle missing mapillary images

### DIFF
--- a/src/components/StreetProject.vue
+++ b/src/components/StreetProject.vue
@@ -70,6 +70,7 @@ export default defineComponent({
   data() {
     return {
       arrowKeys: true,
+      currentImageId: undefined,
       isLoading: true,
       results: {},
       startTime: null,
@@ -125,6 +126,7 @@ export default defineComponent({
 
 <template>
   <project-header :instructionMessage="instructionMessage" :title="project?.projectTopic">
+    {{ group.groupId }} {{ taskId }}
     <project-info
       :first="first"
       :informationPages="createInformationPages(tutorial, project, createFallbackInformationPages)"
@@ -136,10 +138,14 @@ export default defineComponent({
       </template>
     </project-info>
   </project-header>
-  <street-project-task :taskId="taskId" @dataloading="(e) => (isLoading = e.loading)" />
+  <street-project-task
+    :taskId="taskId"
+    @dataloading="(e) => (isLoading = e.loading)"
+    @image="(e) => (currentImageId = e.image.id)"
+  />
   <option-buttons
     v-if="taskId"
-    :disabled="isLoading"
+    :disabled="isLoading || taskId != currentImageId"
     :options="options"
     :result="results[taskId]"
     :taskId="taskId"

--- a/src/components/StreetProjectTask.vue
+++ b/src/components/StreetProjectTask.vue
@@ -34,6 +34,7 @@ export default defineComponent({
       this.viewer.deactivateComponent('sequence')
       this.viewer.deactivateComponent('keyboard')
       this.viewer.on('dataloading', (e) => this.$emit('dataloading', e))
+      this.viewer.on('image', (e) => this.$emit('image', e))
     },
     resetView() {
       this.viewer.setCenter([0.5, 0.5])

--- a/src/components/StreetProjectTask.vue
+++ b/src/components/StreetProjectTask.vue
@@ -12,12 +12,13 @@ export default defineComponent({
   },
   data() {
     return {
+      imageError: false,
       viewer: null,
     }
   },
   watch: {
     taskId(newTaskId) {
-      this.viewer.moveTo(newTaskId).then(() => this.resetView())
+      this.moveViewer(newTaskId)
     },
   },
   methods: {
@@ -26,7 +27,6 @@ export default defineComponent({
         accessToken: import.meta.env.VITE_MAPILLARY_API_KEY,
         component: { cover: false },
         container: 'mapillary',
-        imageId: imageId,
         renderMode: 0, // Letterbox
       })
 
@@ -34,7 +34,20 @@ export default defineComponent({
       this.viewer.deactivateComponent('sequence')
       this.viewer.deactivateComponent('keyboard')
       this.viewer.on('dataloading', (e) => this.$emit('dataloading', e))
-      this.viewer.on('image', (e) => this.$emit('image', e))
+
+      this.moveViewer(imageId)
+    },
+    moveViewer(imageId) {
+      this.viewer.moveTo(imageId).then(
+        () => {
+          this.imageError = false
+          this.resetView()
+        },
+        () => {
+          this.imageError = true
+          this.$emit('imageError', imageId)
+        },
+      )
     },
     resetView() {
       this.viewer.setCenter([0.5, 0.5])
@@ -50,9 +63,13 @@ export default defineComponent({
 <template>
   <v-container
     id="mapillary"
-    class="ma-0 pa-0"
+    :class="'ma-0 pa-0' + (imageError ? ' error' : '')"
     style="position: relative; height: calc(100vh - 375px)"
   />
 </template>
 
-<style scoped></style>
+<style scoped>
+#mapillary.error {
+  filter: opacity(20%) brightness(0%);
+}
+</style>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -203,7 +203,8 @@
   "streetProject": {
     "moveLeft": "Zurück",
     "moveRight": "Weiter",
-    "lookFor": "Suche {lookFor}"
+    "lookFor": "Suche {lookFor}",
+    "couldNotLoadImage": "Leider konnten wir dieses Bild nicht laden. Bitte mache mit der nächsten Aufgabe weiter."
   },
   "digitizeProjectInstructions": {
     "switchMode": "Editiermodus umschalten",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -203,7 +203,8 @@
   "streetProject": {
     "moveLeft": "Back",
     "moveRight": "Forward",
-    "lookFor": "Look for {lookFor}"
+    "lookFor": "Look for {lookFor}",
+    "couldNotLoadImage": "Sorry, we could not load this image. Please proceed to the next task."
   },
   "digitizeProjectInstructions": {
     "switchMode": "Switch editing mode",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -203,7 +203,8 @@
   "streetProject": {
     "moveLeft": "Précédent",
     "moveRight": "Suivant",
-    "lookFor": "Rechercher {lookFor}"
+    "lookFor": "Rechercher {lookFor}",
+    "couldNotLoadImage": "Désolé, nous n'avons pas pu charger cette image. Veuillez continuer avec la tâche suivante."
   },
   "digitizeProjectInstructions": {
     "switchMode": "Activer/désactiver le mode Édition",


### PR DESCRIPTION
In some cases, Mapillary coverage tiles contain locations of images that are actually unavailable (e.g. currently the image with id `26345560905089892`). As a consequence, the project creation worker may create task groups that have tasks with missing images.

Before this PR, the web app did not handle cases of missing imagery on Mapillary correctly. 

This PR introduces the following behaviour of the web client upon an error of the moveTo method of the Mapillary viewer:

* disable the option buttons, so that the user cannot provide an answer to the task
* grey out the viewer
* display a snackbar message informing the user about the image loading error
* keep the task navigation buttons enabled, so that the user can move one task forward despite not having answered
* Set `null` as the value of the task in the results object, so that no result will be written to Firebase for the respective task

![Peek 2025-01-21 16-22](https://github.com/user-attachments/assets/4ec500e4-a9f4-476c-a4e5-43ba63ea67ac)
