### PR TITLE
Fix fetch tutorial tasks

### DIFF
--- a/src/components/CompareProject.vue
+++ b/src/components/CompareProject.vue
@@ -104,6 +104,10 @@ export default defineComponent({
       type: Object as PropType<Tutorial>,
       required: false,
     },
+    tutorialTasks: {
+      type: Array as PropType<Task[]>,
+      required: false,
+    },
   },
   data(): {
     allAnswered: boolean
@@ -208,6 +212,7 @@ export default defineComponent({
       <template #tutorial>
         <compare-project-tutorial
           :tutorial="tutorial"
+          :tasks="tutorialTasks"
           :options="options"
           @tutorialComplete="$refs.projectInfo?.toggleDialog"
         />

--- a/src/components/CompareProjectTutorial.vue
+++ b/src/components/CompareProjectTutorial.vue
@@ -1,14 +1,11 @@
 <script lang="ts">
 import { defineComponent, type PropType } from 'vue'
-import { goOnline, onValue } from 'firebase/database'
-import { db, getTasksRef, getGroupsRef } from '@/firebase'
 import matchIcon from '@/utils/matchIcon'
 import OptionButtons from '@/components/OptionButtons.vue'
 import { type Option } from '@/components/OptionButtons.vue'
 import CompareProjectTask, { type Task } from '@/components/CompareProjectTask.vue'
 import TutorialCompletionCard from './TutorialCompletionCard.vue'
 import TaskProgress from '@/components/TaskProgress.vue'
-import { decompressTasks } from '@/utils/tasks'
 import { isDefined } from '@/utils/common'
 
 interface Screen {
@@ -41,16 +38,18 @@ export default defineComponent({
       type: Array as PropType<Option[]>,
       required: true,
     },
+    tasks: {
+      type: Array as PropType<Task[]>,
+      required: true,
+    },
   },
   data(): {
-    tasks: Task[]
     currentTaskIndex: number
     results: Record<string, number>
     userAttempts: number
     answersRevealed: boolean
   } {
     return {
-      tasks: [],
       currentTaskIndex: 0,
       results: {},
       userAttempts: 0,
@@ -136,37 +135,6 @@ export default defineComponent({
     },
   },
   methods: {
-    fetchTutorialGroups() {
-      if (this.tutorial?.projectId) {
-        onValue(
-          getGroupsRef(this.tutorial.projectId),
-          (snapshot) => {
-            const data = snapshot.val()
-            const groupKeys = Object.keys(data)
-            this.fetchTutorialProject(groupKeys[0])
-          },
-          (error) => {
-            console.error('Error fetching tasks for the tutorial', error)
-          },
-          { onlyOnce: true },
-        )
-      }
-    },
-    fetchTutorialProject(groupId: string | undefined) {
-      if (this.tutorial?.projectId && groupId) {
-        onValue(
-          getTasksRef(this.tutorial.projectId, groupId),
-          (snapshot) => {
-            const data = snapshot.val()
-            this.tasks = decompressTasks(data)
-          },
-          (error) => {
-            console.error('Error fetching tasks for the tutorial', error)
-          },
-          { onlyOnce: true },
-        )
-      }
-    },
     nextTask() {
       if (!this.hasCompletedAllTasks) {
         this.currentTaskIndex += 1
@@ -186,10 +154,6 @@ export default defineComponent({
     },
   },
   emits: ['tutorialComplete'],
-  mounted() {
-    goOnline(db)
-    this.fetchTutorialGroups()
-  },
 })
 </script>
 

--- a/src/components/FindProject.vue
+++ b/src/components/FindProject.vue
@@ -51,7 +51,11 @@ export default defineComponent({
     },
     tutorial: {
       type: Object,
-      require: false,
+      required: false,
+    },
+    tutorialTasks: {
+      type: Array,
+      required: false,
     },
   },
   data() {
@@ -385,6 +389,7 @@ export default defineComponent({
       <template #tutorial>
         <find-project-tutorial
           :tutorial="tutorial"
+          :tasks="tutorialTasks"
           :options="options"
           @tutorialComplete="$refs.projectInfo?.toggleDialog"
         />

--- a/src/components/FindProjectTutorial.vue
+++ b/src/components/FindProjectTutorial.vue
@@ -47,7 +47,7 @@ export default defineComponent({
       required: true,
     },
     tasks: {
-      type: Array,
+      type: Array as PropType<Task[]>,
       required: true,
     },
   },

--- a/src/components/StreetProject.vue
+++ b/src/components/StreetProject.vue
@@ -71,6 +71,10 @@ export default defineComponent({
       type: Object,
       required: false,
     },
+    tutorialTasks: {
+      type: Array,
+      required: false,
+    },
   },
   data() {
     return {
@@ -156,6 +160,7 @@ export default defineComponent({
       <template #tutorial>
         <street-project-tutorial
           :tutorial="tutorial"
+          :tasks="tutorialTasks"
           :options="options"
           @tutorialComplete="$refs.projectInfo?.toggleDialog"
         />

--- a/src/components/StreetProjectTutorial.vue
+++ b/src/components/StreetProjectTutorial.vue
@@ -1,8 +1,5 @@
 <script lang="ts">
 import { defineComponent, type PropType } from 'vue'
-import { goOnline, onValue } from 'firebase/database'
-import { db, getTasksRef, getGroupsRef } from '@/firebase'
-import { decompressTasks } from '@/utils/tasks'
 import matchIcon from '@/utils/matchIcon'
 import OptionButtons from '@/components/OptionButtons.vue'
 import TaskProgress from '@/components/TaskProgress.vue'
@@ -52,9 +49,12 @@ export default defineComponent({
   props: {
     tutorial: Object as PropType<Tutorial>,
     options: Array as PropType<Option[]>,
+    tasks: {
+      type: Array as PropType<Task[]>,
+      required: true,
+    },
   },
   data(): {
-    tasks: Task[]
     currentTaskIndex: number
     results: Record<string, number>
     userAttempts: number
@@ -62,7 +62,6 @@ export default defineComponent({
     isLoading: boolean
   } {
     return {
-      tasks: [],
       currentTaskIndex: 0,
       results: {},
       userAttempts: 0,
@@ -148,38 +147,6 @@ export default defineComponent({
     },
   },
   methods: {
-    fetchTutorialGroups() {
-      if (this.tutorial?.projectId) {
-        onValue(
-          // FIXME: verify group id
-          getGroupsRef(this.tutorial.projectId),
-          (snapshot) => {
-            const data = snapshot.val()
-            const groupKeys = Object.keys(data)
-            this.fetchTutorialProject(groupKeys[0])
-          },
-          (error) => {
-            console.error('Error fetching tasks for the tutorial', error)
-          },
-          { onlyOnce: true },
-        )
-      }
-    },
-    fetchTutorialProject(groupId: string | undefined) {
-      if (this.tutorial?.projectId && groupId) {
-        onValue(
-          getTasksRef(this.tutorial.projectId, groupId),
-          (snapshot) => {
-            const data = snapshot.val()
-            this.tasks = decompressTasks(data)
-          },
-          (error) => {
-            console.error('Error fetching tasks for the tutorial', error)
-          },
-          { onlyOnce: true },
-        )
-      }
-    },
     nextTask() {
       if (!this.hasCompletedAllTasks) {
         this.currentTaskIndex += 1
@@ -199,10 +166,6 @@ export default defineComponent({
     },
   },
   emits: ['tutorialComplete'],
-  mounted() {
-    goOnline(db)
-    this.fetchTutorialGroups()
-  },
 })
 </script>
 

--- a/src/components/ValidateProject.vue
+++ b/src/components/ValidateProject.vue
@@ -73,6 +73,10 @@ export default defineComponent({
       type: Object,
       require: false,
     },
+    tutorialTasks: {
+      type: Array,
+      required: false,
+    },
   },
   data() {
     return {
@@ -197,6 +201,7 @@ export default defineComponent({
       <template #tutorial>
         <validate-project-tutorial
           :tutorial="tutorial"
+          :tasks="tutorialTasks"
           :options="options"
           @tutorialComplete="$refs.projectInfo?.toggleDialog"
         />

--- a/src/components/ValidateProjectTutorial.vue
+++ b/src/components/ValidateProjectTutorial.vue
@@ -1,11 +1,8 @@
 <script lang="ts">
 import { defineComponent, type PropType } from 'vue'
-import { goOnline, onValue } from 'firebase/database'
-import { db, getTasksRef, getGroupsRef } from '@/firebase'
 import matchIcon from '@/utils/matchIcon'
 import OptionButtons from '@/components/OptionButtons.vue'
 import TaskProgress from '@/components/TaskProgress.vue'
-import { decompressTasks } from '@/utils/tasks'
 import ValidateProjectTask, { type Project } from './ValidateProjectTask.vue'
 import TutorialCompletionCard from './TutorialCompletionCard.vue'
 import { isDefined } from '@/utils/common'
@@ -57,16 +54,15 @@ export default defineComponent({
   props: {
     tutorial: Object as PropType<Tutorial>,
     options: Array as PropType<Option[]>,
+    tasks: Array as PropType<Task[]>,
   },
   data(): {
-    tasks: Task[]
     currentTaskIndex: number
     results: Record<string, number>
     userAttempts: number
     answersRevealed: boolean
   } {
     return {
-      tasks: [],
       currentTaskIndex: 0,
       results: {},
       userAttempts: 0,
@@ -153,37 +149,6 @@ export default defineComponent({
     },
   },
   methods: {
-    fetchTutorialGroups() {
-      if (this.tutorial?.projectId) {
-        onValue(
-          getGroupsRef(this.tutorial.projectId),
-          (snapshot) => {
-            const data = snapshot.val()
-            const groupKeys = Object.keys(data)
-            this.fetchTutorialProject(groupKeys[0])
-          },
-          (error) => {
-            console.error('Error fetching tasks for the tutorial', error)
-          },
-          { onlyOnce: true },
-        )
-      }
-    },
-    fetchTutorialProject(groupId: string | undefined) {
-      if (this.tutorial?.projectId && groupId) {
-        onValue(
-          getTasksRef(this.tutorial.projectId, groupId),
-          (snapshot) => {
-            const data = snapshot.val()
-            this.tasks = decompressTasks(data)
-          },
-          (error) => {
-            console.error('Error fetching tasks for the tutorial', error)
-          },
-          { onlyOnce: true },
-        )
-      }
-    },
     nextTask() {
       if (!this.hasCompletedAllTasks) {
         this.currentTaskIndex += 1
@@ -203,10 +168,6 @@ export default defineComponent({
     },
   },
   emits: ['tutorialComplete'],
-  mounted() {
-    goOnline(db)
-    this.fetchTutorialGroups()
-  },
 })
 </script>
 

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -39,7 +39,7 @@ export default defineComponent({
     return {
       completedGroupId: null,
       group: null,
-      mode: 'contribute',
+      mode: 'prepare',
       mappingSpeed: 1,
       nextDialog: false,
       project: null,
@@ -126,7 +126,9 @@ export default defineComponent({
         const data = snapshot.val() || {}
         this.project = data
         if (this.project?.tutorialId) {
-          this.bindTutorial()
+          this.bindTutorial(this.project?.tutorialId)
+        } else {
+          this.mode = 'contribute'
         }
       })
     },
@@ -168,17 +170,18 @@ export default defineComponent({
         this.tasks = decompressTasks(data)
       })
     },
-    bindTutorial() {
-      onValue(getProjectRef(this.project?.tutorialId), (snapshot) => {
+    bindTutorial(tutorialId) {
+      onValue(getProjectRef(tutorialId), (snapshot) => {
         const data = snapshot.val() || {}
         this.tutorial = data
-        this.bindTutorialTasks()
+        this.bindTutorialTasks(tutorialId)
       })
     },
-    bindTutorialTasks() {
-      onValue(getTasksRef(this.tutorial?.projectId, '101'), (snapshot) => {
+    bindTutorialTasks(tutorialId) {
+      onValue(getTasksRef(tutorialId, '101'), (snapshot) => {
         const data = snapshot.val()
         this.tutorialTasks = decompressTasks(data)
+        this.mode = 'contribute'
       })
     },
     completeOptions(option, index) {

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -46,6 +46,7 @@ export default defineComponent({
       projectContributions: [],
       tasks: null,
       tutorial: null,
+      tutorialTasks: null,
       to: null,
     }
   },
@@ -171,6 +172,13 @@ export default defineComponent({
       onValue(getProjectRef(this.project?.tutorialId), (snapshot) => {
         const data = snapshot.val() || {}
         this.tutorial = data
+        this.bindTutorialTasks()
+      })
+    },
+    bindTutorialTasks() {
+      onValue(getTasksRef(this.tutorial?.projectId, '101'), (snapshot) => {
+        const data = snapshot.val()
+        this.tutorialTasks = decompressTasks(data)
       })
     },
     completeOptions(option, index) {
@@ -251,6 +259,7 @@ export default defineComponent({
       :project="project"
       :tasks="tasks"
       :tutorial="tutorial"
+      :tutorialTasks="tutorialTasks"
       @created="handleTaskComponentCreated"
     />
 


### PR DESCRIPTION
Tutorial tasks are loaded in ProjectView and handed over to the tutorial component via the task component. Thus, it is avoided to open the Firebase connection after the task component has loaded, as this may result in triggering a reload of a (different) task group if the Firebase data on the task group changes in the meantime.

Closes #65